### PR TITLE
Fixed setting JSON Configuration with old or nil data

### DIFF
--- a/Source/HNManager.m
+++ b/Source/HNManager.m
@@ -287,7 +287,7 @@ static HNManager * _sharedManager = nil;
             NSString *newData = [[NSString alloc] initWithData:data encoding:NSUTF8StringEncoding];
             [[NSUserDefaults standardUserDefaults] setValue:newData forKey:kHNJSONConfigurationKey];
             [[NSUserDefaults standardUserDefaults] synchronize];
-            self.JSONConfiguration = [NSJSONSerialization JSONObjectWithData:jsonData options:NSJSONReadingAllowFragments error:nil];
+            self.JSONConfiguration = [NSJSONSerialization JSONObjectWithData:data options:NSJSONReadingAllowFragments error:nil];
             [[NSNotificationCenter defaultCenter] postNotificationName:kHNShouldReloadDataFromConfiguration object:nil];
         }
     }];


### PR DESCRIPTION
This fixes two things with `downloadAndSetConfiguration`:

* Crash on app first launch as it tries to call `NSJSONSerialization JSONObjectWithData:options:error:` with a nil data parameter and the exception isn't caught
* Setting an old configuration even after downloading a new one