### PR TITLE
Avoid getting comments for job posts

### DIFF
--- a/Source/HNWebService.m
+++ b/Source/HNWebService.m
@@ -143,6 +143,12 @@
 
 #pragma mark - Load Comments from Post
 - (void)loadCommentsFromPost:(HNPost *)post completion:(GetCommentsCompletion)completion {
+    // Job posts don't have any comments
+    if (post.Type == HNCommentTypeJobs) {
+        completion(nil);
+        return;
+    }
+
     // Create URL Path
     NSString *urlPath = [NSString stringWithFormat:@"%@item?id=%@", kBaseURLAddress, post.PostId];
     


### PR DESCRIPTION
HN job posts don’t allow comments and always return “No such item” from the API. This currently causes `loadPostsWithUrlAddition:completion:` to return a single comment with nil properties. This instead returns a nil object and avoids the network request.